### PR TITLE
Updater misses update?

### DIFF
--- a/tests/Variable.js
+++ b/tests/Variable.js
@@ -171,6 +171,8 @@ define([
 			});
 			var mult = sum.map(function(s) { return s.valueOf() * 2; });
 			assert.equal(mult.valueOf(), 10);
+			b.put(4);
+			assert.equal(mult.valueOf(), 12);
 		},
 		derivedMapWithArray: function() {
 			var a = new Variable([2]);
@@ -183,6 +185,26 @@ define([
 			assert.deepEqual(sum.valueOf(), [5]);
 			var mult = sum.map(function(s) { return [s.valueOf()[0] * 2]; });
 			assert.deepEqual(mult.valueOf(), [10]);
+			b.put([4]);
+                        assert.deepEqual(mult.valueOf(), [12]);
+		},
+                derivedComposedInvalidations: function() {
+			var outer = new Variable(false);
+			var signal = new Variable();
+			var arr = [1,2,3];
+			var data = signal.map(function() { return arr; });
+			var inner = data.map(function(arr) { return arr.map(function(o) { return o*2; }); });
+			var derived = outer.map(function (processing) {
+				return inner.map(function(arr){
+					return [processing, arr];
+				});
+			});
+			assert.deepEqual(derived.valueOf(), [false, [2,4,6]]);
+			outer.put(true);
+			arr = [4,5,6];
+			signal.invalidate();
+			outer.put(false);
+			assert.deepEqual(derived.valueOf(), [false, [8,10,12]]);
 		},
 		mapWithArray: function() {
 			var values = [0,1,2,3,4,5]

--- a/tests/Variable.js
+++ b/tests/Variable.js
@@ -193,10 +193,10 @@ define([
 			var signal = new Variable();
 			var arr = [1,2,3];
 			var data = signal.map(function() { return arr; });
-			var inner = data.map(function(arr) { return arr.map(function(o) { return o*2; }); });
-			var derived = outer.map(function (processing) {
-				return inner.map(function(arr){
-					return [processing, arr];
+			var inner = data.map(function(a) { return a.map(function(v) { return v*2; }); });
+			var derived = outer.map(function (o) {
+				return inner.map(function(i){
+					return [o, i];
 				});
 			});
 			assert.deepEqual(derived.valueOf(), [false, [2,4,6]]);


### PR DESCRIPTION
I ran into a very puzzling case, which I _think_ the included Updater test case reveals as something having to do with how promises and animation frames are interleaved.  If an intermediate animation frame does not occur in this case where a derived variable value is invalidated by two dependencies, then it appears the last state of one of the variables is not observed by the Updater.  If an intermediate animation frame occurs, then all states are observed. (you can flip the boolean to test both cases)
I am hoping this is not an artifact of my test case, it mirrors actual behavior I am running into; I think the additional (succeeding) Variable test isolates this the Updater.
