### PR TITLE
support multiple classes on manually instantiated element

### DIFF
--- a/Element.js
+++ b/Element.js
@@ -703,7 +703,7 @@
 						if (applyOnCreate.className) {
 							applyOnCreate.className += ' ' + name
 						} else {
-							element.className = name
+							element.classList.add(name)
 						}
 					} else {
 						if (applyOnCreate.id) {

--- a/Element.js
+++ b/Element.js
@@ -703,7 +703,11 @@
 						if (applyOnCreate.className) {
 							applyOnCreate.className += ' ' + name
 						} else {
-							element.classList.add(name)
+							if (element.className) {
+							    element.className += ' ' + name
+							} else {
+							    element.className = name
+							}
 						}
 					} else {
 						if (applyOnCreate.id) {

--- a/tests/Element.js
+++ b/tests/Element.js
@@ -415,8 +415,10 @@ define([
 					b: b
 				}
 			})
+                        var div2 = new Div('.one.two')
 			document.body.appendChild(div)
 			return new Promise(requestAnimationFrame).then(function() {
+				assert.strictEqual(div2.className, 'one two')
 				assert.strictEqual(div.className, 'first second third b')
 				a.put(true)
 				return new Promise(requestAnimationFrame).then(function() {


### PR DESCRIPTION
small fix. i'm not sure if `applyOnCreate` is relevant here, but appending the classname generates the result that matches the implicit element creation path.