### PR TITLE
Ensure attached() and detached() are only called once for a given element when ocurring in multiple mutation trees

### DIFF
--- a/tests/Element.js
+++ b/tests/Element.js
@@ -548,29 +548,35 @@ define([
 		},
 		lifecycle: function() {
 			var created = false
-			var attached = false
-			var detached = false
-			MyDiv = extend(Div, {
+			var attached = 0
+			var detached = 0
+			var MyDiv = extend(Div, {
 				created: function(properties) {
 					if (properties.foo) {
 						created = true
 					}
+					var div = document.createElement('div')
+					this.appendChild(div)
 				},
 				attached: function() {
-					attached = true
+					console.log('attached called')
+					attached++
 				},
 				detached: function() {
-					detached = true
+					detached++
 				}
 			})
+			var parentEl = document.createElement('div')
+			document.body.appendChild(parentEl)
 			var div = new MyDiv({foo: 'bar'})
 			assert.isTrue(created)
-			document.body.appendChild(div)
+			parentEl.appendChild(div)
 			return new Promise(requestAnimationFrame).then(function() {
-				assert.isTrue(attached)
-				document.body.removeChild(div)
+				assert.equal(attached, 1, 'expected a single attach event')
+				parentEl.removeChild(div)
+				document.body.removeChild(parentEl)
 				return new Promise(requestAnimationFrame).then(function() {
-					assert.isTrue(detached)
+					assert.equal(detached, 1, 'expected a single detach event')
 				})
 			})
 		},

--- a/tests/Element.js
+++ b/tests/Element.js
@@ -559,7 +559,6 @@ define([
 					this.appendChild(div)
 				},
 				attached: function() {
-					console.log('attached called')
 					attached++
 				},
 				detached: function() {


### PR DESCRIPTION
an element and parent may both appear in the mutation list, ensure that lifecycle events are only called once

i suppose weird things could happen if a given node appears both in removed and added nodes but i assume the browser ensures this can't happen