### PR TITLE
Use createDocumentFragment to append alkali iterables

### DIFF
--- a/Element.js
+++ b/Element.js
@@ -137,7 +137,8 @@ define(['./Variable', './Renderer', './util/lang'], function (Variable, Renderer
 					}
 				} else if (child.notifies) {
 					// a variable
-					fragment.appendChild(childNode = variableAsContent(parent, child))
+					var ref = child.isIterable ? fragment : parent
+					fragment.appendChild(childNode = variableAsContent(ref, child))
 				} else if (typeof child == 'object') {
 					if (child instanceof Array) {
 						// array of sub-children
@@ -1026,7 +1027,7 @@ define(['./Variable', './Renderer', './util/lang'], function (Variable, Renderer
 		if (typeof Target === 'object') {
 			// we were given an actual instance, use that
 			var elementMap = From.ownedClasses || (From.ownedClasses = new WeakMap())
-			var instanceMap = {get: function () { 
+			var instanceMap = {get: function () {
 				return Target
 			}}
 			elementMap.set(Target.constructor, instanceMap)

--- a/Variable.js
+++ b/Variable.js
@@ -8,7 +8,7 @@ define(['./util/lang'], function (lang) {
 	// update types
 	var RequestChange = 3
 	var RequestSet = 4
-	
+
 	var ToChild = Object.freeze({
 		type: 'refresh'
 	})
@@ -331,7 +331,7 @@ define(['./util/lang'], function (lang) {
 
 				if (!context) {
 					parentContext.addInput(this)
-				}				
+				}
 			}
 			if (value && value.then) {
 				return when(value, function(value) {
@@ -366,7 +366,7 @@ define(['./util/lang'], function (lang) {
 				subject = subject.target
 			}
 			if (this.parent) {
-				return this.parent.for(subject).property(this.key)	
+				return this.parent.for(subject).property(this.key)
 			}
 			return new ContextualizedVariable(this, subject || defaultContext)
 		},
@@ -1067,7 +1067,7 @@ define(['./util/lang'], function (lang) {
 					context.addInput(contextualizedVariable)
 				}
 				return contextualizedVariable.cachedValue
-			}			
+			}
 
 			var variable = this
 			function withComputedValue(computedValue) {
@@ -1242,7 +1242,7 @@ define(['./util/lang'], function (lang) {
 							return deny
 						}
 					}, context)
-				});				
+				});
 			})
 		},
 		invoke: function(functionValue, context, observeArguments) {
@@ -1333,7 +1333,7 @@ define(['./util/lang'], function (lang) {
 			return this.generic.put(value, subject.getContextualized ? subject : new Context(subject))
 		}
 	})
-	
+
 	var IterativeMethod = lang.compose(Composite, function(source, method, args) {
 		this.source = source
 		// source.interestWithin = true
@@ -1371,7 +1371,7 @@ define(['./util/lang'], function (lang) {
 					}
 					// if not an array convert to an array
 					array = [array]
-				} 
+				}
 				if (typeof method === 'string') {
 					// apply method
 					return array[method].apply(array, args)
@@ -1397,6 +1397,7 @@ define(['./util/lang'], function (lang) {
 	function defineArrayMethod(method, constructor, properties) {
 		var IterativeResults = lang.compose(IterativeMethod, constructor, properties)
 		IterativeResults.prototype.method || (IterativeResults.prototype.method = method)
+		Object.defineProperty(IterativeResults.prototype, 'isIterable', {value: true});
 		Variable.prototype[method] = function() {
 			var results = new IterativeResults()
 			results.source = this
@@ -1540,7 +1541,7 @@ define(['./util/lang'], function (lang) {
 			} else {
 				// a fresh start
 				i = 0
-				generatorIterator = this.generator()				
+				generatorIterator = this.generator()
 			}
 
 			do {
@@ -1877,6 +1878,6 @@ define(['./util/lang'], function (lang) {
 
 	Variable.all = all
 	Variable.objectUpdated = objectUpdated
-	
+
 	return Variable
 })

--- a/tests/Element.js
+++ b/tests/Element.js
@@ -27,6 +27,7 @@ define([
 	var append = Element.append
 	var prepend = Element.prepend
 	var extend = Element.extend
+	var VArray = Variable.VArray
 	registerSuite({
 		name: 'Element',
 		simpleElement: function () {
@@ -264,13 +265,23 @@ define([
 			assert.strictEqual(middle.className, 'middle-1')
 		},
 
+		childrenDOMOrderWithVariables: function(){
+			const Vars = [1, 2, 3].map(v => new Variable(v));
+			const children = [
+			  'First node ', new VArray(Vars).map(v => Span([v]))
+			];
+			const div = new Div(children);
+			document.body.appendChild(div)
+			assert.strictEqual(div.firstChild.nodeType, 3)
+		},
+
 		append: function() {
 			var top = new Div('.top')
 			append(top, Span, Span('.second'))
 			assert.strictEqual(top.firstChild.tagName, 'SPAN')
 			assert.strictEqual(top.firstChild.nextSibling.className, 'second')
 		},
-		
+
 		appendAsMethod: function() {
 			HTMLElement.prototype.append = append
 			var top = new Div('.top')
@@ -289,7 +300,7 @@ define([
 			assert.strictEqual(top.firstChild.nextSibling.className, 'second')
 			assert.strictEqual(top.firstChild.nextSibling.nextSibling.className, 'last')
 		},
-		
+
 		list: function() {
 			var arrayVariable = new Variable(['a', 'b', 'c'])
 			var listElement = new UL({


### PR DESCRIPTION
When inserting `VArray`s as children in a contructor the DOM order gets inverted. 
This is a bit intrusive since it adds a Boolean property `isIterable` in `IterativeResults.prototype`.
Spec included.

Let me know what you think or if this can/should be fixed somewhere else.