### PR TITLE
Prevent assignment of identical new property value

### DIFF
--- a/Renderer.js
+++ b/Renderer.js
@@ -257,7 +257,9 @@
 		if (newValue == null || (element.type === 'number' && isNaN(newValue))) {
 			newValue = ''
 		}
-		element[this.name] = newValue
+		if (element[this.name] != newValue) {
+			element[this.name] = newValue
+		}
 	}
 	InputPropertyRenderer.prototype.renderSelectValueUpdate = function (newValue, element) {
 		element.value = newValue


### PR DESCRIPTION
I believe this can prevent side-effects resulting from property assignment (like repositioning of the cursor in a text input field) when the new value is identical to the old value (which can arise depending on `inputEvents` being listened to)