### PR TITLE
dstore: test for listener registration idempotency and deregistration

### DIFF
--- a/extensions/dstore.js
+++ b/extensions/dstore.js
@@ -5,18 +5,18 @@ define(['../util/lang', '../Variable'], function(lang, Variable){
 	{
 		gotValue: function(value, context) {
 			value = Variable.prototype.gotValue.call(this, value, context)
-			if (value && value.on && !(this.seen || (this.seen = new Set())).has(value)){
+			if (value && value.on && !(this._lastDSValue === value)){
 				// if it an object that can deliver notifications through `on` events, we listen for that (like dstore collections)
 				var variable = this
 				var handle = value.on(['add','update','delete'], function(event) {
 					event.visited = new Set()
 					variable.updated(event)
 				})
-				var seen = this.seen.add(value)
+				this._lastDSValue = value
 				this.returnedVariable = {
 					// remove the listener when we unsubscribe
 					stopNotifies: function() {
-						seen.delete(value)
+						variable._lastDSValue = undefined
 						handle.remove()
 					},
 					notifies: function(){}

--- a/extensions/dstore.js
+++ b/extensions/dstore.js
@@ -5,15 +5,20 @@ define(['../util/lang', '../Variable'], function(lang, Variable){
 	{
 		gotValue: function(value, context) {
 			value = Variable.prototype.gotValue.call(this, value, context)
-			if (value && value.on){
+			if (value && value.on && !(this.seen || (this.seen = new Set())).has(value)){
 				// if it an object that can deliver notifications through `on` events, we listen for that (like dstore collections)
 				var variable = this
 				var handle = value.on(['add','update','delete'], function(event) {
 					event.visited = new Set()
 					variable.updated(event)
 				})
+				var seen = this.seen.add(value)
 				this.returnedVariable = {
-					stopNotifies: handle.remove, // remove the listener when we unsubscribe
+					// remove the listener when we unsubscribe
+					stopNotifies: function() {
+						seen.delete(value)
+						handle.remove()
+					},
 					notifies: function(){}
 				}
 			}

--- a/tests/dstore.js
+++ b/tests/dstore.js
@@ -100,13 +100,13 @@ define([
 			assert.equal(m1.handlers.length, 1)
 			storeVar.put(m2)
 			storeVar.valueOf()
-			assert.equal(m1.handlers.length, 1)
+			assert.equal(m1.handlers.length, 0)
 			assert.equal(m2.handlers.length, 1)
 			// put seen m1 again
 			storeVar.put(m1)
 			storeVar.valueOf()
 			assert.equal(m1.handlers.length, 1)
-			assert.equal(m2.handlers.length, 1)
+			assert.equal(m2.handlers.length, 0)
 		}
 	})
 })

--- a/tests/dstore.js
+++ b/tests/dstore.js
@@ -6,6 +6,18 @@ define([
 	'intern/chai!assert'
 ], function (Variable, dstore, Memory, registerSuite, assert) {
 	var DstoreVariable = dstore.DstoreVariable
+	function MockStore() {
+		this.handlers = []
+		this.on = function(events, f) {
+			this.handlers.push(f)
+			var that = this
+			return {
+				remove: function() {
+					that.handlers = that.handlers.filter(function(h) { return h !== f })
+				}
+			}
+		}
+	}
 	registerSuite({
 		name: 'dstore',
 		dstoreUpdates: function() {
@@ -56,6 +68,45 @@ define([
 				result.push({i: item.id, n: item.name})
 			})
 			assert.deepEqual(result, [{i:1,n:'one'},{i:2,n:'two'},{i:3,n:'three'}])
+		},
+		listenerRemovedWhenVariableChanged: function() {
+			var m1 = new MockStore()
+			var m2 = new MockStore()
+			assert.equal(m1.handlers.length, 0)
+			assert.equal(m2.handlers.length, 0)
+			var storeVar = new DstoreVariable()
+			storeVar.put(m1)
+			storeVar.valueOf()
+			assert.equal(m1.handlers.length, 1)
+			assert.equal(m2.handlers.length, 0)
+			storeVar.put(m2)
+			storeVar.valueOf()
+			assert.equal(m1.handlers.length, 0)
+			assert.equal(m2.handlers.length, 1)
+		},
+		listenerRegistrationIdempotent: function() {
+			var m1 = new MockStore()
+			var m2 = new MockStore()
+			assert.equal(m1.handlers.length, 0)
+			assert.equal(m2.handlers.length, 0)
+			var storeVar = new DstoreVariable()
+			storeVar.put(m1)
+			storeVar.valueOf()
+			assert.equal(m1.handlers.length, 1)
+			storeVar.valueOf()
+			assert.equal(m1.handlers.length, 1)
+			storeVar.put(m1)
+			storeVar.valueOf()
+			assert.equal(m1.handlers.length, 1)
+			storeVar.put(m2)
+			storeVar.valueOf()
+			assert.equal(m1.handlers.length, 1)
+			assert.equal(m2.handlers.length, 1)
+			// put seen m1 again
+			storeVar.put(m1)
+			storeVar.valueOf()
+			assert.equal(m1.handlers.length, 1)
+			assert.equal(m2.handlers.length, 1)
 		}
 	})
 })


### PR DESCRIPTION
given I'm likely to move away from this extension take it for what it's worth, but I discovered that it seems like listeners could be getting redundantly registered and/or not deregistered with dstore extension; this could in theory be problematic when `valueOf` is called in tight loops (generating many callback closures)