### PR TITLE
various attempts at implementing transparently composable Promises

### DIFF
--- a/Variable.js
+++ b/Variable.js
@@ -985,6 +985,13 @@
 			// easiest way to cast to a variable class
 			return new Class(this)
 		},
+		asPromised: function(defaultValue) {
+			const output = new Variable(defaultValue)
+			this.subscribe(function(e) {
+				Promise.resolve(e.value()).then(function(value) { output.put(value) })
+			})
+			return new Transform(output)
+		},
 		get schema() {
 			// default schema is the constructor
 			if (this.returnedVariable) {

--- a/tests/Variable.js
+++ b/tests/Variable.js
@@ -1254,6 +1254,29 @@ define([
 					assert.equal(t.valueOf(), '<a>')
 				})
 			})
-		}
+		},
+
+		asPromised: function() {
+			var s = new Variable(new Promise(function (r) {
+				setTimeout(function() {	r('a') }, 100)
+			}))
+			var v = s.asPromised()
+			assert.equal(v.valueOf(), undefined)
+			return new Promise(setTimeout).then(function () {
+				// still initial/undefined value
+				assert.equal(v.valueOf(), undefined)
+				return new Promise(function (r) { setTimeout(r, 150) }).then(function() {
+					// should contain resolved value now
+					assert.equal(v.valueOf(), 'a')
+					s.put(new Promise(function (r) {
+						setTimeout(function() {	r('b')	}, 100)
+					}))
+					assert.equal(v.valueOf(), 'a')
+					return new Promise(function (r) { setTimeout(r, 300) }).then(function() {
+						assert.equal(v.valueOf(), 'b')
+					})
+				})
+			})
+		},
 	})
 })

--- a/util/lang.js
+++ b/util/lang.js
@@ -369,6 +369,13 @@
 			for(var i in properties) {
 				prototype[i] = properties[i]
 			}
+			// copy descriptors
+			if (properties) {
+				var pnames = Object.getOwnPropertyNames(properties)
+				for (var i = 0; i < pnames.length; i++) {
+					Object.defineProperty(prototype, pnames[i], Object.getOwnPropertyDescriptor(properties, pnames[i]))
+				}
+      }
 			prototype.constructor = constructor
 			return constructor
 		},


### PR DESCRIPTION
Gave a shot at implementing this.  One desirable (although possibly not mandatory) characteristic would be returning the "previous" value the variable held, while currently holding a Promise value.  I wasn't able to follow all the conditions under which this value gets set/returned; i ended up overriding `this.value` via a setter/getter, although I wasn't successful in capturing/intercepting all possibilities.
Alternative is to just return `undefined` whenever the Variable holds an unfulfilled Promise, which will work as long as the consuming code knows how to interpret this.

Update: updated with a simple helper that just does the decoupled subscribe/put