### PR TITLE
add type for static `all` method

### DIFF
--- a/typings.d.ts
+++ b/typings.d.ts
@@ -22,6 +22,8 @@ declare namespace alkali {
     subscribe(observable: { next: (T) => any})
     as<U>(Type: { new(): U }): U
 
+    static all(inputs: Array<any>): Variable<Array<any>>
+    static all(...inputs: Array<any>): Variable<Array<any>>
     static with<U>(properties: {[P in keyof U]: { new(): U[P] }}): VariableClass<U>
     static assign<U>(properties: {[P in keyof U]: { new(): U[P] }}): VariableClass<U>
 

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -22,7 +22,7 @@ declare namespace alkali {
     subscribe(observable: { next: (T) => any})
     as<U>(Type: { new(): U }): U
 
-    static all(inputs: Array<any>): Variable<Array<any>>
+    static all(inputs: Array<any>, transform?: (v:any) => any): Variable<Array<any>>
     static all(...inputs: Array<any>): Variable<Array<any>>
     static with<U>(properties: {[P in keyof U]: { new(): U[P] }}): VariableClass<U>
     static assign<U>(properties: {[P in keyof U]: { new(): U[P] }}): VariableClass<U>


### PR DESCRIPTION
Defined arguments as `any`, and also defined the vararg override.  Alter as needed.

(when accepting only `Variable<any>`, showing types working in IntelliJ IDEA:)
![variable-all](https://user-images.githubusercontent.com/77031/28378612-c7eaa894-6c7e-11e7-921a-7636211cfa5e.png)
