### PR TITLE
add tests for transformation depending on promise

### DIFF
--- a/tests/operators.js
+++ b/tests/operators.js
@@ -18,6 +18,29 @@ define([
       assert.isTrue(operators.equal(v, v2).valueOf())
       assert.isTrue(operators.add(v, v2) instanceof VNumber)
       assert.equal(operators.add(v, v2).valueOf(), 4)
+    },
+    conjunctionNegation: function() {
+      var s = new Variable()
+      var d = s.to(function(s) {
+        return s && new Promise(function(r) {
+          setTimeout(function() { r('promised') }, 100)
+        })
+      })
+      s._debug = 'source'
+      d._debug = 'promised'
+      const notLoading = operators.or(operators.not(s), d)
+      assert.isTrue(notLoading.valueOf())
+      var upstream = new Variable()
+      upstream._debug = 'upstream'
+      s.put(upstream)
+      assert.isTrue(!!notLoading.valueOf())
+      upstream.put('source')
+      return new Promise(function(r) { setTimeout(function() { r() }, 50) }).then(function () {
+        assert.isFalse(!!notLoading.valueOf(), 'expected to be still loading (source selected, derived not fulfilled)')
+	    return new Promise(function(r) { setTimeout(function() { r() }, 100) }).then(function () {
+		  assert.isTrue(!!notLoading.valueOf(), 'expected to have fully loaded (source selected and derived has been fulfilled)')
+	    })
+      })
     }
   })
 })


### PR DESCRIPTION
Line 906 of Element.js fails when I would have expected it to succeed.  This likely is not related to operators but seems similar to a previous case where I think I expected an invalidation of a promise-holding Variable to invalidate downstream transforms.  I'm not quite sure why the operators test passes, while the equivalent `valueOf()` results on line 906 seem to confirm conflicting values (transform output does conform to input values).

This scenario roughly imitates asynchronously loading content based on a selection a user has made (or not yet made in the initial state).