### PR TITLE
Type updates

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,5 +1,5 @@
 {
-	"asi": false,
+	"asi": true,
 	"bitwise": false,
 	"boss": false,
 	"browser": true,

--- a/index.d.ts
+++ b/index.d.ts
@@ -41,7 +41,7 @@ declare namespace alkali {
     * Returns a variable corresponding to the property of the value of this variable
     * @param key The name of the property
     */
-    property<K extends keyof T>(key: KeyType): Variable<T[K]>
+    property<K extends keyof T>(key: K): Variable<YieldedValue<T[K]>>
     property<U>(key: KeyType, PropertyClass: { new(): U }): U
     /**
     * Assigns a new value to this variables (which marks it as updated and any listeners will be notified). This is a request to change the variable, and subclasses can reject the put request, or return asynchronously.
@@ -52,13 +52,13 @@ declare namespace alkali {
     * Gets the property value of this variable's value/object. This differs from `property` in that it returns the resolved value, not a variable
     * @param key The name of the property
     */
-    get<K extends keyof T>(key: KeyType): T[K]
+    get<K extends keyof T>(key: K): YieldedValue<T[K]>
     /**
     * Assigns a value to the property of this variable's value
     * @param key The name of the property
     * @param value The new value to assign to the property
     */
-    set<K extends keyof T>(key: KeyType, value: T[K] | Variable<T[K]> | Promise<T[K]>, event?: UpdateEvent): void
+    set<K extends keyof T>(key: K, value: T[K] | Variable<T[K]> | Promise<T[K]>, event?: UpdateEvent): void
     /**
     * Assigns undefined to the property of this variable's value
     * @param key The name of the property
@@ -154,7 +154,7 @@ declare namespace alkali {
     then<U>(callback: (value: T) => U | Promise<U>, errback: (value: T) => U | Promise<U>): Promise<U>
     for(subject: any): Variable<T2>
     to<U>(transform: (value: T) => U | Variable<U>): VariableClass<U>
-    property<K extends keyof T2>(key: KeyType): VariableClass<T2[K]>
+    property<K extends keyof T2>(key: K): VariableClass<T2[K]>
   }
 
   export type Reacts<T> = {[P in keyof T]?: Reacts<T[P]>} & Variable<T>

--- a/index.d.ts
+++ b/index.d.ts
@@ -15,8 +15,8 @@ declare namespace alkali {
   }
 
   // support heterogenous inputs https://github.com/Microsoft/TypeScript/pull/26063
-  type YieldedValue<T> = T extends Variable<infer U> ? U : T;
-  type Yield<T> = { [P in keyof T]: YieldedValue<T[P]> };
+  type YieldedValue<T> = T extends Variable<infer U> ? U : T
+  type Yield<T> = { [P in keyof T]: YieldedValue<T[P]> }
 
   export class Variable<T = {}> implements Promise<T> {
     /**
@@ -148,7 +148,7 @@ declare namespace alkali {
     valueOf(): T
     then<U>(callback: (T) => U | Promise<U>, errback: (T) => U | Promise<U>): Promise<U>
     for(subject: any): Variable<T2>
-    to<U>(transform: (T) => U | Variable<U>): VariableClass<U>
+    to<U>(transform: (value: T) => U | Variable<U>): VariableClass<U>
     property<K extends keyof T2>(key: KeyType): VariableClass<T2[K]>
   }
 
@@ -161,7 +161,7 @@ declare namespace alkali {
 
   export class VArray<T = {}> extends Variable<Array<T>> implements Set<T> {
     constructor(value?: Array<T> | Promise<Array<T>> | Variable<Array<T>>)
-    readonly length: VNumber
+    readonly length: typeof VNumber
     /**
     * Return a VArray with the map applied
     */

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "scripts": {
     "test": "./node_modules/.bin/mocha tests/unit -u tdd",
     "test.sauce": "intern-runner config=tests/intern",
-    "test.proxy": "intern-runner config=tests/intern --proxyOnly"
+    "test.proxy": "intern-runner config=tests/intern --proxyOnly",
+    "test.types": "./node_modules/.bin/tsc -p tests"
   },
   "main": "./index.js",
   "dependencies": {},

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "es6",
+    "lib": ["DOM", "ES2017", "ScriptHost"],
+    "noEmit": true
+    //"strict": true,
+    //"strictNullChecks": false
+  },
+  "files": [ "./types.ts" ]
+}

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -2,9 +2,9 @@
   "compilerOptions": {
     "target": "es6",
     "lib": ["DOM", "ES2017", "ScriptHost"],
-    "noEmit": true
-    //"strict": true,
-    //"strictNullChecks": false
+    "noEmit": true,
+    "strict": true,
+    "strictNullChecks": false
   },
   "files": [ "./types.ts" ]
 }

--- a/tests/types.ts
+++ b/tests/types.ts
@@ -1,5 +1,5 @@
 /// <reference path="../index.d.ts" />
-import { Variable, VArray, VNumber, all, reactive, Reacts, VariableClass } from 'alkali'
+import { Variable, VArray, VNumber, all, reactive, Reacts, VariableClass, Promise as AlkaliPromise } from 'alkali'
 
 // Variable, Primitive-Typed Variable, reactive/Reacts compatibility
 let vi = new Variable(1)
@@ -33,6 +33,21 @@ let Rn: Reacts<number>
   //t = vi
   t = vn
   //t = rn
+}
+// put, then
+{
+  const p = new Variable<string>('p')
+  let sr: string | Variable<string> | AlkaliPromise<string> = p.put('string')
+  let vr: string | Variable<string> | AlkaliPromise<string> = p.put(new Variable('string var'))
+  p.then(s => s.toLowerCase())
+}
+// subscription
+{
+  const v = new Variable('a')
+  const subscription = v.subscribe(e => {
+    const str: string = e.value()
+  })
+  subscription.unsubscribe()
 }
 
 // test heterogeneous variadic types
@@ -142,8 +157,17 @@ let Rn: Reacts<number>
   })
 }
 
-// VArray length
+// VArray
 {
   const a = new VArray(['a','b'])
-  const len: VariableClass<boolean, {}> = a.length.to(n => n < 2)
+  const doubled: VariableClass<boolean, {}> = a.length.to(n => n < 1)
+  const reduced = a.map(s => s.toLowerCase()).filter(s => s.split('/')).reduce((memo, s, i) => {
+    memo[i] = s
+    return memo
+  }, { MEMO: true } as { [key: number]: string, MEMO: true })
+  const r = reduced.valueOf()
+  const b: boolean = r.MEMO
+  //r['0']
+  const s: string = r[0]
+  const l: boolean = a.map(s => s.length).every(n => n < 2).valueOf()
 }

--- a/tests/types.ts
+++ b/tests/types.ts
@@ -171,3 +171,36 @@ let Rn: Reacts<number>
   const s: string = r[0]
   const l: boolean = a.map(s => s.length).every(n => n < 2).valueOf()
 }
+// properties
+{
+  let o = {
+    str: 'string',
+    num: 1,
+    vb: new Variable(true),
+    inner: new Variable({
+      x: 2,
+      y: new Variable({
+        a: false
+      })
+    })
+  }
+  let vo = new Variable(o)
+  const s: string = vo.get('str')
+  const num: number = vo.get('num')
+  const b: boolean = vo.get('vb')
+  const inner = vo.get('inner')
+  const x: number = inner.x
+  //const y = inner.y
+  //const yab: boolean = y.a
+  let ps: Variable<string> = vo.property('str')
+  let pnum: Variable<number> = vo.property('num')
+  let pvb: Variable<boolean> = vo.property('vb')
+  let r = pvb.valueOf()
+  let pvo = vo.property('inner')
+  let pvoy = pvo.property('y')
+  let avalue0: boolean = pvoy.get('a')
+  let a = pvo.property('y').property('a')
+  let avalue1: boolean = a.valueOf()
+
+  vo.set('str', 123) // should fail type check
+}

--- a/tests/types.ts
+++ b/tests/types.ts
@@ -1,0 +1,143 @@
+/// <reference path="../index.d.ts" />
+import { Variable, VNumber, all, reactive, Reacts } from 'alkali'
+
+// Variable, Primitive-Typed Variable, reactive/Reacts compatibility
+let vi = new Variable(1)
+let vn = new VNumber(1)
+let rn = reactive(1)
+let Rn: Reacts<number>
+{
+  let t = vi
+  t.valueOf().toFixed()
+  t = vn
+  //t = rn
+  t = Rn
+}
+{
+  let t = vn
+  t.valueOf().toFixed()
+  //t = vi
+  //t = rn
+  t = Rn
+}
+{
+  let t = rn
+  t.valueOf().toFixed()
+  t = vi
+  t = vn
+  t = Rn
+}
+{
+  let t = Rn
+  t.valueOf().toFixed()
+  //t = vi
+  t = vn
+  //t = rn
+}
+
+// test heterogeneous variadic types
+{
+  const vs = new Variable<string>('a').to(s => `[${s}]`)
+  const vn = new Variable(new Variable(1))
+  const s = 'three'
+  const n = 4
+  // variadic args
+  let a: Variable<[string, number, string, number]> = all(vs, vn, s, n)
+  let r = a.to(([str, num, str2, num2]) => {
+    let s: string = str, n: number = num, s2: string = str2, n2: number = num2
+    str.toLowerCase()
+    str2.toLowerCase()
+    num.toFixed()
+    num2.toFixed()
+    return { s: str, n: num }
+  }).to(r => {
+    r.s.toLowerCase()
+    r.n.toFixed()
+    return r
+  }).valueOf()
+  r.s.toLowerCase()
+  r.n.toFixed()
+
+  // array arg
+  a =  all([vs, vn, s, n])
+  r = a.to(([str, num, str2, num2]) => {
+    let s: string = str, n: number = num, s2: string = str2, n2: number = num2
+    str.toLowerCase()
+    str2.toLowerCase()
+    num.toFixed()
+    num2.toFixed()
+    return { s: str, n: num }
+  }).to(r => {
+    r.s.toLowerCase()
+    r.n.toFixed()
+    return r
+  }).valueOf()
+  r.s.toLowerCase()
+  r.n.toFixed()
+}
+{
+  // homogeneous primitive array type
+  const numberArray = [1,2,3]
+  let a: Variable<number[]> = all(numberArray)
+  a.to(([one, two, three]) => {
+    let n: number = one, n2: number = two, n3: number = three
+    one.toFixed()
+    two.toFixed()
+    three.toFixed()
+  })
+  // mixed primitive type array
+  const mixedArray = ['1', 2] // (string|number)[]
+  let b = all(mixedArray).to(([one, two]) => {
+    let arg0: string|number = one, arg1: string|number = two
+    // guard disambiguates string|number
+    if (typeof one === 'string') {
+      one.toLowerCase()
+    } else {
+      // if not string, must be number
+      let other: number = one
+      one.toFixed()
+    }
+    if (typeof two === 'number') {
+      two.toFixed()
+    } else {
+      // if not number, must be string
+      let other: string = two
+      two.toLowerCase()
+    }
+  })
+}
+{
+  // homogeneous variable array type
+  const vnumberArray: Variable<number>[] = [
+    new Variable(1),
+    new Variable(new Variable(2)),
+    new Variable(3).to(n => n*2)
+  ]
+  let a: Variable<number[]> = all(vnumberArray)
+  a.to(([one, two, three]) => {
+    let n: number = one
+    one.toFixed()
+    two.toFixed()
+    three.toFixed()
+  })
+  // mixed variable type array
+  const mixedArray = [new Variable('1'), new Variable(2)] // (Variable<string>|Variable<number>)[]
+  let b = all(mixedArray).to(([one, two]) => {
+    let arg0: string|number = one, arg1: string|number = two
+    // guard disambiguates string|number
+    if (typeof one === 'string') {
+      one.toLowerCase()
+    } else {
+      // if not string, must be number
+      let other: number = one
+      one.toFixed()
+    }
+    if (typeof two === 'number') {
+      two.toFixed()
+    } else {
+      // if not number, must be string
+      let other: string = two
+      two.toLowerCase()
+    }
+  })
+}

--- a/tests/types.ts
+++ b/tests/types.ts
@@ -1,5 +1,5 @@
 /// <reference path="../index.d.ts" />
-import { Variable, VNumber, all, reactive, Reacts } from 'alkali'
+import { Variable, VArray, VNumber, all, reactive, Reacts, VariableClass } from 'alkali'
 
 // Variable, Primitive-Typed Variable, reactive/Reacts compatibility
 let vi = new Variable(1)
@@ -140,4 +140,10 @@ let Rn: Reacts<number>
       two.toLowerCase()
     }
   })
+}
+
+// VArray length
+{
+  const a = new VArray(['a','b'])
+  const len: VariableClass<boolean, {}> = a.length.to(n => n < 2)
 }


### PR DESCRIPTION
Updates type decls, enables heterogenous types on `all()` calls so types propagate:

```typescript
all(new Variable('s'), new Variable(1), false).to(([str, num, bool]) => {
  const s: string = str
  const n: number = num
  const b: boolean = bool
})
```